### PR TITLE
fix(git): local git config

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -49,3 +49,5 @@
 	default = simple
 [commit]
 	gpgsign = true
+[include]
+  path = ~/.git_local


### PR DESCRIPTION
Running config commands in .zsh_local was updating my main .gitconfig.
Turns out you can `[include]` an override file from your main .gitconfig
file.